### PR TITLE
feat(setup.py): limit pathlib only to py3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
         'PyYAML',
         'numpy',
         'pyrx',
-        'pathlib',
+        'pathlib; python_version<"3.4"',
         'docopt'],
 )


### PR DESCRIPTION
It was added to the standard library in 3.4. The pypi package `pathlib` is no longer maintained.